### PR TITLE
fix: Fix pyproject.toml structure for Read the Docs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -21,5 +21,3 @@ python:
     - requirements: docs/requirements.txt
     - method: pip
       path: .
-      extra_requirements:
-        - docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,12 +16,6 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
 ]
-
-[project.urls]
-Homepage = "https://github.com/chughtapan/restful-mcp"
-Documentation = "https://restful-mcp.readthedocs.io"
-Repository = "https://github.com/chughtapan/restful-mcp"
-Issues = "https://github.com/chughtapan/restful-mcp/issues"
 dependencies = [
     # Core framework dependencies
     "pydantic>=2.11.5",
@@ -45,6 +39,12 @@ dependencies = [
     "mkdocs-material>=9.5.0",
     "mkdocstrings[python]>=0.24.0",
 ]
+
+[project.urls]
+Homepage = "https://github.com/chughtapan/restful-mcp"
+Documentation = "https://restful-mcp.readthedocs.io"
+Repository = "https://github.com/chughtapan/restful-mcp"
+Issues = "https://github.com/chughtapan/restful-mcp/issues"
 
 [project.scripts]
 restful-mcp-agent = "restful_mcp.agent:main"


### PR DESCRIPTION
- Move dependencies field to correct location under [project]
- Remove extra_requirements from .readthedocs.yaml as we don't have optional deps
- This fixes the metadata generation error on Read the Docs